### PR TITLE
Implement aggregation and grouping pushdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 srcdir       = .
 MODULE_big   = multicorn
-OBJS         =  src/errors.o src/python.o src/query.o src/multicorn.o
+OBJS         = src/deparse.o src/errors.o src/python.o src/query.o src/multicorn.o
 
 
 DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))
@@ -19,7 +19,7 @@ directories.stamp:
 
 $(OBJS): directories.stamp
 
-install: python_code 
+install: python_code
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql directories.stamp
 	cp $< $@

--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -212,6 +212,21 @@ class ForeignDataWrapper(object):
         """
         return []
 
+    def can_pushdown_upperrel(self):
+        """
+        Method called from the planner to ask the FDW whether it supports upper
+        relation pushdown (i.e. aggregation, grouping, etc.), and if so return
+        a data structure with appropriate details.
+
+        The FDW has to inspect every sort, and respond which one are handled.
+        The sorts are cumulatives.
+
+        Return:
+            None if pushdown not supported, otherwise a dictionary containing
+            more granular details for the planning phase, in the form:
+        """
+        return None
+
     def get_path_keys(self):
         u"""
         Method called from the planner to add additional Path to the planner.

--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -280,7 +280,7 @@ class ForeignDataWrapper(object):
         """
         return []
 
-    def execute(self, quals, columns, sortkeys=None):
+    def execute(self, quals, columns, sortkeys=None, aggs=None, group_clauses=None):
         """Execute a query in the foreign data wrapper.
 
         This method is called at the first iteration.
@@ -311,8 +311,15 @@ class ForeignDataWrapper(object):
                 You should return AT LEAST those columns when returning a
                 dict. If returning a sequence, every column from the table
                 should be in the sequence.
+
+        Kwargs:
             sortkeys (list): A list of :class:`SortKey`
                 that the FDW said it can enforce.
+            aggs (dict): A dictionary mapping aggregation key with function and
+                column to be used in the aggregation operation. Result should be
+                returned under the provided aggregation key.
+            group_clauses (list): A list of columns used in GROUP BY statements.
+                The result should be returned for each column name provided.
 
         Returns:
             An iterable of python objects which can be converted back to PostgreSQL.

--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -218,12 +218,22 @@ class ForeignDataWrapper(object):
         relation pushdown (i.e. aggregation, grouping, etc.), and if so return
         a data structure with appropriate details.
 
-        The FDW has to inspect every sort, and respond which one are handled.
-        The sorts are cumulatives.
-
         Return:
             None if pushdown not supported, otherwise a dictionary containing
             more granular details for the planning phase, in the form:
+
+            {
+                "groupby_supported": <true_or_false>, # can be ommited if false
+                "agg_functions": {
+                    <PG_agg_func_name>: <foreign_agg_func_name>,
+                    ...
+                },
+            }
+
+            Each entry in `agg_functions` dict corresponds to a maping between
+            the name of a aggregation function in PostgreSQL, and the equivalent
+            foreign function. If no mapping exists for an aggregate function any
+            queries containing it won't be pushed down.
         """
         return None
 
@@ -334,7 +344,8 @@ class ForeignDataWrapper(object):
                 column to be used in the aggregation operation. Result should be
                 returned under the provided aggregation key.
             group_clauses (list): A list of columns used in GROUP BY statements.
-                The result should be returned for each column name provided.
+                For each column provided the returned response should have a
+                corresponding value in each row using that column name as the key.
 
         Returns:
             An iterable of python objects which can be converted back to PostgreSQL.

--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -284,7 +284,7 @@ class ForeignDataWrapper(object):
         """
         return []
 
-    def explain(self, quals, columns, sortkeys=None, verbose=False):
+    def explain(self, quals, columns, sortkeys=None, aggs=None, group_clauses=None, verbose=False):
         """Hook called on explain.
 
         The arguments are the same as the :meth:`execute`, with the addition of

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -157,10 +157,8 @@ multicorn_foreign_expr_walker(Node *node,
 	if (node == NULL)
 		return true;
 
-    // MY CODE START
     /* Needed to asses per-instance FDW shipability properties */
 	fpinfo = (MulticornPlanState *) (glob_cxt->foreignrel->fdw_private);
-    // MY CODE END
 
 	/* Set up inner_cxt for possible recursion to child nodes */
 	inner_cxt.collation = InvalidOid;
@@ -241,11 +239,12 @@ multicorn_foreign_expr_walker(Node *node,
 				if (schema != PG_CATALOG_NAMESPACE)
 					return false;
 
-                // MY CODE START
-				/* Make sure the specific function at hand is shippable */
+				/* Make sure the specific function at hand is shippable
+                 * NB: here we deviate from standard FDW code, since the allowed
+                 * function list is fetched from the Python FDW instance
+                 */
 				if (!list_member(fpinfo->agg_functions, makeString(opername)))
 					return false;
-                // MY CODE END
 
 				/* Not safe to pushdown when not in grouping context */
 				if (!IS_UPPER_REL(glob_cxt->foreignrel))
@@ -255,14 +254,12 @@ multicorn_foreign_expr_walker(Node *node,
 				if (agg->aggsplit != AGGSPLIT_SIMPLE)
 					return false;
 
-                // MY CODE START
                 /*
                  * For now we don't push down DISTINCT or COUNT(*) aggregations.
                  * TODO: Enable this
                  */
                 if (agg->aggdistinct || agg->aggstar)
                     return false;
-                // MY CODE END
 
 				/*
 				 * Recurse to input args. aggdirectargs, aggorder and
@@ -527,7 +524,6 @@ multicorn_build_tlist_to_deparse(RelOptInfo *foreignrel)
 	return tlist;
 }
 
-// MY CODE START
 /*
  * Iterate through the targets and extract relveant information needed to execute
  * the aggregation and/or grouping on the remote data source through Python.
@@ -605,4 +601,3 @@ multicorn_deparse_function_name(Oid funcid)
 	ReleaseSysCache(proctup);
     return makeString(proname);
 }
-// MY CODE END

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -240,9 +240,8 @@ multicorn_foreign_expr_walker(Node *node,
 					return false;
 
 				/* Make sure the specific function at hand is shippable */
-				if (!PySequence_Contains(fpinfo->agg_functions, PyUnicode_FromString(opername)))
+				if (!list_member(fpinfo->agg_functions, makeString(opername)))
 					return false;
-
 
 				/* Not safe to pushdown when not in grouping context */
 				if (!IS_UPPER_REL(glob_cxt->foreignrel))

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -252,6 +252,10 @@ multicorn_foreign_expr_walker(Node *node,
 				if (agg->aggsplit != AGGSPLIT_SIMPLE)
 					return false;
 
+                /* For now we don't push down aggregations with DISTINCT  */
+                if (agg->aggdistinct)
+                    return false;
+
 				/*
 				 * Recurse to input args. aggdirectargs, aggorder and
 				 * aggdistinct are all present in args, so no need to check

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -252,8 +252,11 @@ multicorn_foreign_expr_walker(Node *node,
 				if (agg->aggsplit != AGGSPLIT_SIMPLE)
 					return false;
 
-                /* For now we don't push down aggregations with DISTINCT  */
-                if (agg->aggdistinct)
+                /*
+                 * For now we don't push down DISTINCT or COUNT(*) aggregations.
+                 * TODO: Enable this
+                 */
+                if (agg->aggdistinct || agg->aggstar)
                     return false;
 
 				/*

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -75,10 +75,6 @@ typedef struct foreign_loc_cxt
 } foreign_loc_cxt;
 
 static Value *multicorn_deparse_function_name(Oid funcid);
-static void multicorn_deparse_explicit_target_list(List *tlist,
-                                    bool is_returning,
-                                    List **retrieved_attrs,
-                                    deparse_expr_cxt *context);
 
 /*
  * Examine each qual clause in input_conds, and classify them into two groups,
@@ -538,6 +534,7 @@ multicorn_extract_upper_rel_info(PlannerInfo *root, List *tlist, MulticornPlanSt
     Var *var;
     Value *colname, *function;
     Aggref *aggref;
+    StringInfo agg_key = makeStringInfo();
 
     foreach(lc, tlist)
     {
@@ -563,9 +560,7 @@ multicorn_extract_upper_rel_info(PlannerInfo *root, List *tlist, MulticornPlanSt
                                             PVC_RECURSE_PLACEHOLDERS));
             colname = colnameFromVar(var, root);
 
-            StringInfo agg_key = makeStringInfo();
             initStringInfo(agg_key);
-
             appendStringInfoString(agg_key, strVal(function));
             appendStringInfoString(agg_key, ".");
             appendStringInfoString(agg_key, strVal(colname));
@@ -585,7 +580,7 @@ multicorn_deparse_function_name(Oid funcid)
 {
 	HeapTuple	proctup;
 	Form_pg_proc procform;
-	const char *proname;
+	char *proname;
 
 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
 	if (!HeapTupleIsValid(proctup))

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -157,8 +157,10 @@ multicorn_foreign_expr_walker(Node *node,
 	if (node == NULL)
 		return true;
 
+    // MY CODE START
     /* Needed to asses per-instance FDW shipability properties */
 	fpinfo = (MulticornPlanState *) (glob_cxt->foreignrel->fdw_private);
+    // MY CODE END
 
 	/* Set up inner_cxt for possible recursion to child nodes */
 	inner_cxt.collation = InvalidOid;
@@ -239,9 +241,11 @@ multicorn_foreign_expr_walker(Node *node,
 				if (schema != PG_CATALOG_NAMESPACE)
 					return false;
 
+                // MY CODE START
 				/* Make sure the specific function at hand is shippable */
 				if (!list_member(fpinfo->agg_functions, makeString(opername)))
 					return false;
+                // MY CODE END
 
 				/* Not safe to pushdown when not in grouping context */
 				if (!IS_UPPER_REL(glob_cxt->foreignrel))
@@ -251,12 +255,14 @@ multicorn_foreign_expr_walker(Node *node,
 				if (agg->aggsplit != AGGSPLIT_SIMPLE)
 					return false;
 
+                // MY CODE START
                 /*
                  * For now we don't push down DISTINCT or COUNT(*) aggregations.
                  * TODO: Enable this
                  */
                 if (agg->aggdistinct || agg->aggstar)
                     return false;
+                // MY CODE END
 
 				/*
 				 * Recurse to input args. aggdirectargs, aggorder and
@@ -521,6 +527,7 @@ multicorn_build_tlist_to_deparse(RelOptInfo *foreignrel)
 	return tlist;
 }
 
+// MY CODE START
 /*
  * Iterate through the targets and extract relveant information needed to execute
  * the aggregation and/or grouping on the remote data source through Python.
@@ -598,3 +605,4 @@ multicorn_deparse_function_name(Oid funcid)
 	ReleaseSysCache(proctup);
     return makeString(proname);
 }
+// MY CODE END

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1,0 +1,577 @@
+/*-------------------------------------------------------------------------
+ *
+ * Multicorn Foreign Data Wrapper for PostgreSQL
+ *
+ * IDENTIFICATION
+ *        deparse.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "pgtime.h"
+#include "access/heapam.h"
+#include "access/htup_details.h"
+#include "access/sysattr.h"
+#include "catalog/pg_aggregate.h"
+#include "catalog/pg_collation.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_operator.h"
+#include "catalog/pg_proc.h"
+#include "catalog/pg_type.h"
+#include "commands/defrem.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/plannodes.h"
+#include "optimizer/clauses.h"
+#include "optimizer/optimizer.h"
+#include "optimizer/tlist.h"
+#include "parser/parsetree.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "utils/timestamp.h"
+#include "utils/typcache.h"
+#include "commands/tablecmds.h"
+
+#include "multicorn.h"
+
+
+/*
+ * Local (per-tree-level) context for multicorn_foreign_expr_walker's search.
+ * This is concerned with identifying collations used in the expression.
+ */
+typedef enum
+{
+	FDW_COLLATE_NONE,			/* expression is of a noncollatable type */
+	FDW_COLLATE_SAFE,			/* collation derives from a foreign Var */
+	FDW_COLLATE_UNSAFE			/* collation derives from something else */
+} FDWCollateState;
+
+
+/*
+ * Global context for multicorn_foreign_expr_walker's search of an expression tree.
+ */
+typedef struct foreign_glob_cxt
+{
+	PlannerInfo *root;			/* global planner state */
+	RelOptInfo *foreignrel;		/* the foreign relation we are planning for */
+
+	/*
+	 * For join pushdown, only a limited set of operators are allowed to be
+	 * pushed.  This flag helps us identify if we are walking through the list
+	 * of join conditions. Also true for aggregate relations to restrict
+	 * aggregates for specified list.
+	 */
+	bool		is_remote_cond;	/* true for join or aggregate relations */
+	Relids		relids;			/* relids of base relations in the underlying
+								 * scan */
+} foreign_glob_cxt;
+
+typedef struct foreign_loc_cxt
+{
+	Oid			collation;		/* OID of current collation, if any */
+	FDWCollateState state;		/* state of current collation choice */
+} foreign_loc_cxt;
+
+static Value *multicorn_deparse_function_name(Oid funcid);
+static void multicorn_deparse_explicit_target_list(List *tlist,
+                                    bool is_returning,
+                                    List **retrieved_attrs,
+                                    deparse_expr_cxt *context);
+
+/*
+ * Return true if given object is one of PostgreSQL's built-in objects.
+ *
+ * We use FirstBootstrapObjectId as the cutoff, so that we only consider
+ * objects with hand-assigned OIDs to be "built in", not for instance any
+ * function or type defined in the information_schema.
+ *
+ * Our constraints for dealing with types are tighter than they are for
+ * functions or operators: we want to accept only types that are in pg_catalog,
+ * else format_type might incorrectly fail to schema-qualify their names.
+ * (This could be fixed with some changes to format_type, but for now there's
+ * no need.)  Thus we must exclude information_schema types.
+ *
+ * XXX there is a problem with this, which is that the set of built-in
+ * objects expands over time.  Something that is built-in to us might not
+ * be known to the remote server, if it's of an older version.  But keeping
+ * track of that would be a huge exercise.
+ */
+static bool
+multicorn_is_builtin(Oid oid)
+{
+	return (oid < FirstBootstrapObjectId);
+}
+
+/*
+ * Check if expression is safe to execute remotely, and return true if so.
+ *
+ * In addition, *outer_cxt is updated with collation information.
+ *
+ * We must check that the expression contains only node types we can deparse,
+ * that all types/functions/operators are safe to send (which we approximate
+ * as being built-in), and that all collations used in the expression derive
+ * from Vars of the foreign table.  Because of the latter, the logic is
+ * pretty close to assign_collations_walker() in parse_collate.c, though we
+ * can assume here that the given expression is valid.
+ */
+static bool
+multicorn_foreign_expr_walker(Node *node,
+						      foreign_glob_cxt *glob_cxt,
+						      foreign_loc_cxt *outer_cxt)
+{
+	bool		check_type = true;
+    //MulticornPlanState *fpinfo;
+	foreign_loc_cxt inner_cxt;
+	Oid			collation = InvalidOid;
+	FDWCollateState state = FDW_COLLATE_NONE;
+	HeapTuple	tuple;
+	Form_pg_operator form;
+
+	/* Need do nothing for empty subexpressions */
+	if (node == NULL)
+		return true;
+
+    /* May need server info from baserel's fdw_private struct */
+	//fpinfo = (MulticornPlanState *) (glob_cxt->foreignrel->fdw_private);
+
+	/* Set up inner_cxt for possible recursion to child nodes */
+	inner_cxt.collation = InvalidOid;
+	inner_cxt.state = FDW_COLLATE_NONE;
+	switch (nodeTag(node))
+	{
+		case T_Var:
+			{
+				Var *var = (Var *) node;
+
+				/*
+				 * If the Var is from the foreign table, we consider its
+				 * collation (if any) safe to use.  If it is from another
+				 * table, we treat its collation the same way as we would a
+				 * Param's collation, ie it's not safe for it to have a
+				 * non-default collation.
+				 */
+				if (bms_is_member(var->varno, glob_cxt->relids) &&
+					var->varlevelsup == 0)
+				{
+					/* Var belongs to foreign table */
+
+					/*
+					 * System columns (e.g. oid, ctid) should not be sent to
+					 * the remote, since we don't make any effort to ensure
+					 * that local and remote values match (tableoid, in
+					 * particular, almost certainly doesn't match).
+					 */
+					if (var->varattno < 0)
+						return false;
+
+					/* Else check the collation */
+					collation = var->varcollid;
+					state = OidIsValid(collation) ? FDW_COLLATE_SAFE : FDW_COLLATE_NONE;
+				}
+				else
+				{
+					/* Var belongs to some other table */
+					collation = var->varcollid;
+					if (collation == InvalidOid ||
+						collation == DEFAULT_COLLATION_OID)
+					{
+						/*
+						 * It's noncollatable, or it's safe to combine with a
+						 * collatable foreign Var, so set state to NONE.
+						 */
+						state = FDW_COLLATE_NONE;
+					}
+					else
+					{
+						/*
+						 * Do not fail right away, since the Var might appear
+						 * in a collation-insensitive context.
+						 */
+						state = FDW_COLLATE_UNSAFE;
+					}
+				}
+			}
+			break;
+		case T_Aggref:
+			{
+				Aggref	   *agg = (Aggref *) node;
+				ListCell   *lc;
+				char	   *opername = NULL;
+				Oid			schema;
+
+				/* get function name and schema */
+				tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(agg->aggfnoid));
+				if (!HeapTupleIsValid(tuple))
+				{
+					elog(ERROR, "cache lookup failed for function %u", agg->aggfnoid);
+				}
+				opername = pstrdup(((Form_pg_proc) GETSTRUCT(tuple))->proname.data);
+				schema = ((Form_pg_proc) GETSTRUCT(tuple))->pronamespace;
+				ReleaseSysCache(tuple);
+
+				/* ignore functions in other than the pg_catalog schema */
+				if (schema != PG_CATALOG_NAMESPACE)
+					return false;
+
+				/* TODO: this decision will need to be forwarded to Python */
+				if (!(strcmp(opername, "sum") == 0
+					  || strcmp(opername, "avg") == 0
+					  || strcmp(opername, "max") == 0
+					  || strcmp(opername, "min") == 0
+					  || strcmp(opername, "count") == 0))
+				{
+					return false;
+				}
+
+
+				/* Not safe to pushdown when not in grouping context */
+				if (!IS_UPPER_REL(glob_cxt->foreignrel))
+					return false;
+
+				/* Only non-split aggregates are pushable. */
+				if (agg->aggsplit != AGGSPLIT_SIMPLE)
+					return false;
+
+				/*
+				 * Recurse to input args. aggdirectargs, aggorder and
+				 * aggdistinct are all present in args, so no need to check
+				 * their shippability explicitly.
+				 */
+				foreach(lc, agg->args)
+				{
+					Node	   *n = (Node *) lfirst(lc);
+
+					/* If TargetEntry, extract the expression from it */
+					if (IsA(n, TargetEntry))
+					{
+						TargetEntry *tle = (TargetEntry *) n;
+
+						n = (Node *) tle->expr;
+					}
+
+					if (!multicorn_foreign_expr_walker(n, glob_cxt, &inner_cxt))
+						return false;
+				}
+
+				if (agg->aggorder || agg->aggfilter)
+				{
+					return false;
+				}
+
+				/*
+				 * If aggregate's input collation is not derived from a
+				 * foreign Var, it can't be sent to remote.
+				 */
+				if (agg->inputcollid == InvalidOid)
+					 /* OK, inputs are all noncollatable */ ;
+				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
+						 agg->inputcollid != inner_cxt.collation)
+					return false;
+
+				/*
+				 * Detect whether node is introducing a collation not derived
+				 * from a foreign Var.  (If so, we just mark it unsafe for now
+				 * rather than immediately returning false, since the parent
+				 * node might not care.)
+				 */
+				collation = agg->aggcollid;
+				if (collation == InvalidOid)
+					state = FDW_COLLATE_NONE;
+				else if (inner_cxt.state == FDW_COLLATE_SAFE &&
+						 collation == inner_cxt.collation)
+					state = FDW_COLLATE_SAFE;
+				else if (collation == DEFAULT_COLLATION_OID)
+					state = FDW_COLLATE_NONE;
+				else
+					state = FDW_COLLATE_UNSAFE;
+			}
+			break;
+		default:
+
+			/*
+			 * If it's anything else, assume it's unsafe.  This list can be
+			 * expanded later, but don't forget to add deparse support below.
+			 */
+			return false;
+	}
+
+	/*
+	 * If result type of given expression is not built-in, it can't be sent to
+	 * remote because it might have incompatible semantics on remote side.
+	 */
+	if (check_type && !multicorn_is_builtin(exprType(node)))
+		return false;
+
+	/*
+	 * Now, merge my collation information into my parent's state.
+	 */
+	if (state > outer_cxt->state)
+	{
+		/* Override previous parent state */
+		outer_cxt->collation = collation;
+		outer_cxt->state = state;
+	}
+	else if (state == outer_cxt->state)
+	{
+		/* Merge, or detect error if there's a collation conflict */
+		switch (state)
+		{
+			case FDW_COLLATE_NONE:
+				/* Nothing + nothing is still nothing */
+				break;
+			case FDW_COLLATE_SAFE:
+				if (collation != outer_cxt->collation)
+				{
+					/*
+					 * Non-default collation always beats default.
+					 */
+					if (outer_cxt->collation == DEFAULT_COLLATION_OID)
+					{
+						/* Override previous parent state */
+						outer_cxt->collation = collation;
+					}
+					else if (collation != DEFAULT_COLLATION_OID)
+					{
+						/*
+						 * Conflict; show state as indeterminate.  We don't
+						 * want to "return false" right away, since parent
+						 * node might not care about collation.
+						 */
+						outer_cxt->state = FDW_COLLATE_UNSAFE;
+					}
+				}
+				break;
+			case FDW_COLLATE_UNSAFE:
+				/* We're still conflicted ... */
+				break;
+		}
+	}
+	/* It looks OK */
+	return true;
+}
+
+/*
+ * Returns true if given expr is safe to evaluate on the foreign server.
+ */
+bool
+multicorn_is_foreign_expr(PlannerInfo *root,
+					      RelOptInfo *baserel,
+					      Expr *expr)
+{
+	foreign_glob_cxt glob_cxt;
+	foreign_loc_cxt loc_cxt;
+	MulticornPlanState *fpinfo = (MulticornPlanState *) (baserel->fdw_private);
+
+	/*
+	 * Check that the expression consists of nodes that are safe to execute
+	 * remotely.
+	 */
+	glob_cxt.root = root;
+	glob_cxt.foreignrel = baserel;
+
+	/*
+	 * For an upper relation, use relids from its underneath scan relation,
+	 * because the upperrel's own relids currently aren't set to anything
+	 * meaningful by the core code.  For other relation, use their own relids.
+	 */
+	if (IS_UPPER_REL(baserel))
+		glob_cxt.relids = fpinfo->outerrel->relids;
+	else
+		glob_cxt.relids = baserel->relids;
+	loc_cxt.collation = InvalidOid;
+	loc_cxt.state = FDW_COLLATE_NONE;
+	if (!multicorn_foreign_expr_walker((Node *) expr, &glob_cxt, &loc_cxt))
+		return false;
+
+	/*
+	 * If the expression has a valid collation that does not arise from a
+	 * foreign var, the expression can not be sent over.
+	 */
+	if (loc_cxt.state == FDW_COLLATE_UNSAFE)
+		return false;
+
+	/*
+	 * An expression which includes any mutable functions can't be sent over
+	 * because its result is not stable.  For example, sending now() remote
+	 * side could cause confusion from clock offsets.  Future versions might
+	 * be able to make this choice with more granularity. (We check this last
+	 * because it requires a lot of expensive catalog lookups.)
+	 */
+	if (contain_mutable_functions((Node *) expr))
+		return false;
+
+	/* OK to evaluate on the remote server */
+	return true;
+}
+
+
+/*
+ * Returns true if given expr is something we'd have to send the value of
+ * to the foreign server.
+ *
+ * This should return true when the expression is a shippable node that
+ * deparseExpr would add to context->params_list.  Note that we don't care
+ * if the expression *contains* such a node, only whether one appears at top
+ * level.  We need this to detect cases where setrefs.c would recognize a
+ * false match between an fdw_exprs item (which came from the params_list)
+ * and an entry in fdw_scan_tlist (which we're considering putting the given
+ * expression into).
+ */
+bool
+multicorn_is_foreign_param(PlannerInfo *root,
+						   RelOptInfo *baserel,
+						   Expr *expr)
+{
+	if (expr == NULL)
+		return false;
+
+	switch (nodeTag(expr))
+	{
+		case T_Var:
+			{
+				/* It would have to be sent unless it's a foreign Var */
+				Var		   *var = (Var *) expr;
+				MulticornPlanState *fpinfo = (MulticornPlanState *) (baserel->fdw_private);
+				Relids		relids;
+
+				if (IS_UPPER_REL(baserel))
+					relids = fpinfo->outerrel->relids;
+				else
+					relids = baserel->relids;
+
+				if (bms_is_member(var->varno, relids) && var->varlevelsup == 0)
+					return false;	/* foreign Var, so not a param */
+				else
+					return true;	/* it'd have to be a param */
+				break;
+			}
+		case T_Param:
+			/* Params always have to be sent to the foreign server */
+			return true;
+		default:
+			break;
+	}
+	return false;
+}
+
+/*
+ * Build the targetlist for given relation to be deparsed as SELECT clause.
+ *
+ * The output targetlist contains the columns that need to be fetched from the
+ * foreign server for the given relation.  If foreignrel is an upper relation,
+ * then the output targetlist can also contains expressions to be evaluated on
+ * foreign server.
+ */
+List *
+multicorn_build_tlist_to_deparse(RelOptInfo *foreignrel)
+{
+	List	   *tlist = NIL;
+	MulticornPlanState *fpinfo = (MulticornPlanState *) foreignrel->fdw_private;
+	ListCell   *lc;
+
+	/*
+	 * For an upper relation, we have already built the target list while
+	 * checking shippability, so just return that.
+	 */
+	if (IS_UPPER_REL(foreignrel))
+		return fpinfo->grouped_tlist;
+
+	/*
+	 * We require columns specified in foreignrel->reltarget->exprs and those
+	 * required for evaluating the local conditions.
+	 */
+	tlist = add_to_flat_tlist(tlist,
+							  pull_var_clause((Node *) foreignrel->reltarget->exprs,
+											  PVC_RECURSE_PLACEHOLDERS));
+	foreach(lc, fpinfo->local_conds)
+	{
+		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+		tlist = add_to_flat_tlist(tlist,
+								  pull_var_clause((Node *) rinfo->clause,
+												  PVC_RECURSE_PLACEHOLDERS));
+	}
+
+	return tlist;
+}
+
+/*
+ * Iterate through the targets and extract relveant information needed to execute
+ * the aggregation and/or grouping on the remote data source through Python.
+ *
+ * NB: Logic here is strongly coupled to multicorn_foreign_grouping_ok(), i.e.
+ * if there is no ressortgroupref set, we automatically assume the only other
+ * option is a Aggref node type.
+ * Moreover, for the Aggref node type we assume only a single element in args
+ * (i.e. only aggregations over single columns, e.g. sum(column2)). In particular,
+ * this is because in multicorn_foreign_expr_walker() we don't T_OpExpr case.
+ */
+void
+multicorn_extract_upper_rel_info(PlannerInfo *root, List *tlist, MulticornPlanState *fpinfo)
+{
+    ListCell *lc;
+    TargetEntry *tle;
+    Var *var;
+    Value *colname, *function;
+    Aggref *aggref;
+
+    foreach(lc, tlist)
+    {
+        tle = lfirst_node(TargetEntry, lc);
+
+        if (tle->ressortgroupref)
+        {
+            /* GROUP BY target */
+            var = (Var *) tle->expr;
+            colname = colnameFromVar(var, root);
+
+            fpinfo->group_clauses = lappend(fpinfo->group_clauses, colname);
+            fpinfo->upper_rel_targets = lappend(fpinfo->upper_rel_targets, colname);
+        }
+        else
+        {
+            /* Aggregation target */
+            aggref = (Aggref *) tle->expr;
+            function = multicorn_deparse_function_name(aggref->aggfnoid);
+
+            var = linitial(pull_var_clause((Node *) aggref,
+                                            PVC_RECURSE_AGGREGATES |
+                                            PVC_RECURSE_PLACEHOLDERS));
+            colname = colnameFromVar(var, root);
+
+            StringInfo agg_key = makeStringInfo();
+            initStringInfo(agg_key);
+
+            appendStringInfoString(agg_key, strVal(function));
+            appendStringInfoString(agg_key, "_");
+            appendStringInfoString(agg_key, strVal(colname));
+
+            fpinfo->aggs = lappend(fpinfo->aggs, list_make3(makeString(agg_key->data), function, colname));
+            fpinfo->upper_rel_targets = lappend(fpinfo->upper_rel_targets, makeString(agg_key->data));
+        }
+    }
+}
+
+/*
+ * multicorn_deparse_function_name
+ *		Deparses function name from given function oid.
+ */
+static Value *
+multicorn_deparse_function_name(Oid funcid)
+{
+	HeapTuple	proctup;
+	Form_pg_proc procform;
+	const char *proname;
+
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	if (!HeapTupleIsValid(proctup))
+		elog(ERROR, "cache lookup failed for function %u", funcid);
+	procform = (Form_pg_proc) GETSTRUCT(proctup);
+
+	proname = NameStr(procform->proname);
+
+	ReleaseSysCache(proctup);
+    return makeString(proname);
+}

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -523,8 +523,8 @@ multicorn_build_tlist_to_deparse(RelOptInfo *foreignrel)
  * if there is no ressortgroupref set, we automatically assume the only other
  * option is a Aggref node type.
  * Moreover, for the Aggref node type we assume only a single element in args
- * (i.e. only aggregations over single columns, e.g. sum(column2)). In particular,
- * this is because in multicorn_foreign_expr_walker() we don't T_OpExpr case.
+ * (e.g. sum(column2)). In particular, this is because in
+ * multicorn_foreign_expr_walker() we don't have T_OpExpr case yet.
  */
 void
 multicorn_extract_upper_rel_info(PlannerInfo *root, List *tlist, MulticornPlanState *fpinfo)

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -1818,13 +1818,6 @@ multicorn_foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 	fpinfo->rel_startup_cost = -1;
 	fpinfo->rel_total_cost = -1;
 
-
-	/*
-	 * Set the string describing this grouped relation to be used in EXPLAIN
-	 * output of corresponding ForeignScan.
-	 */
-    fpinfo->relation_name = NULL;
-
 	return true;
 }
 

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -595,7 +595,7 @@ multicornGetForeignPlan(PlannerInfo *root,
 							serializePlanState(planstate)
 #if PG_VERSION_NUM >= 90500
 							, fdw_scan_tlist
-							, NIL
+							, NULL /* All quals are meant to be rechecked */
 							, outer_plan
 #endif
 							);

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -1782,9 +1782,10 @@ multicorn_foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 	/*
      * TODO: Enable HAVING clause pushdowns.
      * Note that certain simple HAVING clauses get transformed to WHERE clauses
-     * internally, so those will be supported. Example is a HAVING clause on a
-     * column that is also a part of the GROUP BY clause, in which case WHERE
-     * clause effectively achieves the same thing.
+     * internally for performance reasons, i.e. smaller scan size. Example is a
+     * HAVING clause on a column that is also a part of the GROUP BY clause, in
+     * which case WHERE clause effectively achieves the same thing. In those
+     * cases the havingQual is NULL, even though root->hasHavingQual is true.
 	 */
 	if (havingQual)
 	{

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -305,10 +305,12 @@ multicornGetForeignRelSize(PlannerInfo *root,
 
 	baserel->fdw_private = planstate;
 
+    // MY CODE START
     /* Base foreign tables need to be push down always. */
 	planstate->pushdown_safe = true;
     planstate->groupby_supported = false;
     planstate->agg_functions = NULL;
+    // MY CODE END
 
 	planstate->fdw_instance = getInstance(foreigntableid);
 	planstate->foreigntableid = foreigntableid;
@@ -400,6 +402,7 @@ multicornGetForeignRelSize(PlannerInfo *root,
 
 	}
 
+    // MY CODE START
     /*
 	 * Identify which baserestrictinfo clauses can be sent to the remote
 	 * server and which can't.
@@ -410,6 +413,7 @@ multicornGetForeignRelSize(PlannerInfo *root,
 	 */
 	multicorn_classify_conditions(root, baserel, baserel->baserestrictinfo,
 					              &planstate->remote_conds, &planstate->local_conds);
+    // MY CODE END
 
 	/* Inject the "rows" and "width" attribute into the baserel */
 #if PG_VERSION_NUM >= 90600
@@ -576,11 +580,13 @@ multicornGetForeignPlan(PlannerInfo *root,
 		}
 	}
 
+    // MY CODE START
     /* Extract data needed for aggregations on the Python side */
     if (IS_UPPER_REL(foreignrel))
     {
         multicorn_extract_upper_rel_info(root, fdw_scan_tlist, planstate);
     }
+    // MY CODE END
 
 	return make_foreignscan(tlist,
 							scan_clauses,
@@ -641,7 +647,9 @@ multicornBeginForeignScan(ForeignScanState *node, int eflags)
 	{
 		execstate->rel = node->ss.ss_currentRelation;
 		execstate->tupdesc = RelationGetDescr(execstate->rel);
+        // MY CODE START
         initConversioninfo(execstate->cinfos, TupleDescGetAttInMetadata(execstate->tupdesc), NULL);
+        // MY CODE END
 	}
 	else
 	{
@@ -651,7 +659,9 @@ multicornBeginForeignScan(ForeignScanState *node, int eflags)
 #else
 		execstate->tupdesc = node->ss.ss_ScanTupleSlot->tts_tupleDescriptor;
 #endif
+        // MY CODE START
         initConversioninfo(execstate->cinfos, TupleDescGetAttInMetadata(execstate->tupdesc), execstate->upper_rel_targets);
+        // MY CODE END
 	}
 
 	execstate->values = palloc(sizeof(Datum) * execstate->tupdesc->natts);
@@ -1592,6 +1602,7 @@ multicorn_merge_fdw_options(MulticornPlanState *fpinfo,
 	fpinfo->use_remote_estimate = fpinfo_o->use_remote_estimate;
 	fpinfo->fetch_size = fpinfo_o->fetch_size;
 
+    // MY CODE START
     /* Multicorn specific options */
     fpinfo->fdw_instance = fpinfo_o->fdw_instance;
     fpinfo->foreigntableid = fpinfo_o->foreigntableid;
@@ -1601,6 +1612,7 @@ multicorn_merge_fdw_options(MulticornPlanState *fpinfo,
     fpinfo->target_list = fpinfo_o->target_list;
     fpinfo->qual_list = fpinfo_o->qual_list;
     fpinfo->pathkeys = fpinfo_o->pathkeys;
+    // MY CODE END
 
 	/* Merge the table level options from either side of the join. */
 	if (fpinfo_i)
@@ -1779,6 +1791,7 @@ multicorn_foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 		i++;
 	}
 
+    // MY CODE START
 	/*
      * TODO: Enable HAVING clause pushdowns.
      * Note that certain simple HAVING clauses get transformed to WHERE clauses
@@ -1791,6 +1804,7 @@ multicorn_foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 	{
 		return false;
 	}
+    // MY CODE END
 
 	/* Store generated targetlist */
 	fpinfo->grouped_tlist = tlist;
@@ -1848,11 +1862,13 @@ multicornGetForeignUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 	if (stage != UPPERREL_GROUP_AGG || output_rel->fdw_private)
 		return;
 
+    // MY CODE START
     /* Check with the Python FDW instance whether it supports pushdown at all */
     if (!canPushdownUpperrel((MulticornPlanState *) input_rel->fdw_private))
     {
         return;
     }
+    // MY CODE END
 
 	fpinfo = (MulticornPlanState *) palloc0(sizeof(MulticornPlanState));
 	fpinfo->pushdown_safe = false;
@@ -1910,8 +1926,10 @@ multicorn_add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
     fpinfo->table = ifpinfo->table;
 	fpinfo->server = ifpinfo->server;
 	fpinfo->user = ifpinfo->user;
+    // MY CODE START
     fpinfo->groupby_supported = ifpinfo->groupby_supported;
 	fpinfo->agg_functions = ifpinfo->agg_functions;
+    // MY CODE END
     multicorn_merge_fdw_options(fpinfo, ifpinfo, NULL);
 
     /*

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -286,6 +286,11 @@ typedef struct MulticornDeparsedSortGroup
 } MulticornDeparsedSortGroup;
 
 /* deparse.c */
+extern void multicorn_classify_conditions(PlannerInfo *root,
+                                RelOptInfo *baserel,
+                                List *input_conds,
+                                List **remote_conds,
+                                List **local_conds);
 extern bool multicorn_is_foreign_expr(PlannerInfo *root,
 								      RelOptInfo *baserel,
 								      Expr *expr);
@@ -314,6 +319,7 @@ PyObject   *tupleTableSlotToPyObject(TupleTableSlot *slot, ConversionInfo ** cin
 char	   *getRowIdColumn(PyObject *fdw_instance);
 PyObject   *optionsListToPyDict(List *options);
 const char *getPythonEncodingName(void);
+bool canPushdownUpperrel(MulticornPlanState * state);
 
 void getRelSize(MulticornPlanState * state,
 		PlannerInfo *root,

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -59,22 +59,6 @@ typedef struct ConversionInfo
 	bool		need_quote;
 }	ConversionInfo;
 
-
-/*
- * This enum describes what's kept in the fdw_private list for a ForeignPath.
- * We store:
- *
- * 1) Boolean flag showing if the remote query has the final sort
- * 2) Boolean flag showing if the remote query has the LIMIT clause
- */
-enum FdwPathPrivateIndex
-{
-	/* has-final-sort flag (as an integer Value node) */
-	FdwPathPrivateHasFinalSort,
-	/* has-limit flag (as an integer Value node) */
-	FdwPathPrivateHasLimit
-};
-
 /*
  * Context for multicorn_deparse_expr
  */

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -116,6 +116,10 @@ typedef struct MulticornPlanState
 	 */
 	int width;
 
+    /* Details about upperrel pushdown fetched from the Python FDW instance */
+    bool groupby_supported;
+    PyObject *agg_functions;
+
         /*
      * Aggregation and grouping data to be passed to the execution phase.
      * See MulticornExecState for more details.

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -154,13 +154,6 @@ typedef struct MulticornPlanState
 
 	int			fetch_size;		/* fetch size for this remote table */
 
-	/*
-	 * Name of the relation while EXPLAINing ForeignScan. It is used for join
-	 * relations but is set for all relations. For join relation, the name
-	 * indicates which foreign tables are being joined and the join type used.
-	 */
-	char	   *relation_name;
-
 	/* Grouping information */
 	List	   *grouped_tlist;
 }	MulticornPlanState;

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -159,9 +159,6 @@ typedef struct MulticornPlanState
 
 	/* Join information */
 	RelOptInfo *outerrel;
-	RelOptInfo *innerrel;
-	JoinType	jointype;
-	List	   *joinclauses;
 
 	/* Upper relation information */
 	UpperRelationKind stage;
@@ -195,25 +192,6 @@ typedef struct MulticornExecState
 	Datum	   *values;
 	bool	   *nulls;
 	ConversionInfo **cinfos;
-	/* Common buffer to avoid repeated allocations */
-	StringInfo	buffer;
-	AttrNumber	rowidAttno;
-	char	   *rowidAttrName;
-	List	   *pathkeys; /* list of MulticornDeparsedSortGroup) */
-	/* State related to scanning through CStore chunks / temporarily
-	 * materialized tables
-	 */
-	MemoryContext   subscanCxt;
-	void           *subscanState;
-	Relation        subscanRel;
-	TupleTableSlot *subscanSlot;
-	AttrNumber     *subscanAttrMap;
-	uint64          tuplesRead;
-
-    Relation	rel;			/* relcache entry for the foreign table. NULL
-								 * for a foreign join scan. */
-	TupleDesc	tupdesc;		/* tuple descriptor of scan */
-
     /*
      * List containing targets to be returned from Python in case of aggregations.
      * List elements are aggregation keys or group_clauses elements.
@@ -232,6 +210,24 @@ typedef struct MulticornExecState
      * List elements are column names for grouping.
      */
 	List *group_clauses;
+	/* Common buffer to avoid repeated allocations */
+	StringInfo	buffer;
+	AttrNumber	rowidAttno;
+	char	   *rowidAttrName;
+	List	   *pathkeys; /* list of MulticornDeparsedSortGroup) */
+	/* State related to scanning through CStore chunks / temporarily
+	 * materialized tables
+	 */
+	MemoryContext   subscanCxt;
+	void           *subscanState;
+	Relation        subscanRel;
+	TupleTableSlot *subscanSlot;
+	AttrNumber     *subscanAttrMap;
+	uint64          tuplesRead;
+
+    Relation	rel;			/* relcache entry for the foreign table. NULL
+								 * for a foreign join scan. */
+	TupleDesc	tupdesc;		/* tuple descriptor of scan */
 }	MulticornExecState;
 
 typedef struct MulticornModifyState

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -60,6 +60,43 @@ typedef struct ConversionInfo
 }	ConversionInfo;
 
 
+/*
+ * This enum describes what's kept in the fdw_private list for a ForeignPath.
+ * We store:
+ *
+ * 1) Boolean flag showing if the remote query has the final sort
+ * 2) Boolean flag showing if the remote query has the LIMIT clause
+ */
+enum FdwPathPrivateIndex
+{
+	/* has-final-sort flag (as an integer Value node) */
+	FdwPathPrivateHasFinalSort,
+	/* has-limit flag (as an integer Value node) */
+	FdwPathPrivateHasLimit
+};
+
+/*
+ * Context for multicorn_deparse_expr
+ */
+typedef struct deparse_expr_cxt
+{
+	PlannerInfo *root;			/* global planner state */
+	RelOptInfo *foreignrel;		/* the foreign relation we are planning for */
+	RelOptInfo *scanrel;		/* the underlying scan relation. Same as
+								 * foreignrel, when that represents a join or
+								 * a base relation. */
+
+	StringInfo	buf;			/* output buffer to append to */
+	List	  **params_list;	/* exprs that will become remote Params */
+	bool		can_skip_cast;	/* outer function can skip int2/int4/int8/float4/float8 cast */
+} deparse_expr_cxt;
+
+/*
+ * FDW-specific planner information kept in RelOptInfo.fdw_private for a
+ * multicorn foreign table.
+ * multicornGetForeignJoinPaths creates it for a joinrel (not implemented yet),
+ * and mutlicornGetForeignUpperPaths creates it for an upperrel.
+ */
 typedef struct MulticornPlanState
 {
 	Oid			foreigntableid;
@@ -78,6 +115,69 @@ typedef struct MulticornPlanState
 	 * getRelSize to GetForeignPlan.
 	 */
 	int width;
+
+        /*
+     * Aggregation and grouping data to be passed to the execution phase.
+     * See MulticornExecState for more details.
+     */
+    List *upper_rel_targets;
+	List *aggs;
+	List *group_clauses;
+
+    /*
+	 * True means that the relation can be pushed down. Always true for simple
+	 * foreign scan.
+	 */
+	bool		pushdown_safe;
+
+	/* baserestrictinfo clauses, broken down into safe and unsafe subsets. */
+	List	   *remote_conds;
+	List	   *local_conds;
+
+    /* Actual remote restriction clauses for scan (sans RestrictInfos) */
+	List	   *final_remote_exprs;
+
+	/* Estimated size and cost for a scan or join. */
+	double		rows;
+	Cost		startup_cost;
+	Cost		total_cost;
+
+	/* Costs excluding costs for transferring data from the foreign server */
+	double		retrieved_rows;
+	Cost		rel_startup_cost;
+	Cost		rel_total_cost;
+
+	/* Options extracted from catalogs. */
+	bool		use_remote_estimate;
+	Cost		fdw_startup_cost;
+	Cost		fdw_tuple_cost;
+	List	   *shippable_extensions;	/* OIDs of whitelisted extensions */
+
+	/* Join information */
+	RelOptInfo *outerrel;
+	RelOptInfo *innerrel;
+	JoinType	jointype;
+	List	   *joinclauses;
+
+	/* Upper relation information */
+	UpperRelationKind stage;
+
+	/* Cached catalog information. */
+	ForeignTable *table;
+	ForeignServer *server;
+	UserMapping *user;			/* only set in use_remote_estimate mode */
+
+	int			fetch_size;		/* fetch size for this remote table */
+
+	/*
+	 * Name of the relation while EXPLAINing ForeignScan. It is used for join
+	 * relations but is set for all relations. For join relation, the name
+	 * indicates which foreign tables are being joined and the join type used.
+	 */
+	char	   *relation_name;
+
+	/* Grouping information */
+	List	   *grouped_tlist;
 }	MulticornPlanState;
 
 typedef struct MulticornExecState
@@ -105,6 +205,29 @@ typedef struct MulticornExecState
 	TupleTableSlot *subscanSlot;
 	AttrNumber     *subscanAttrMap;
 	uint64          tuplesRead;
+
+    Relation	rel;			/* relcache entry for the foreign table. NULL
+								 * for a foreign join scan. */
+	TupleDesc	tupdesc;		/* tuple descriptor of scan */
+
+    /*
+     * List containing targets to be returned from Python in case of aggregations.
+     * List elements are aggregation keys or group_clauses elements.
+     */
+    List *upper_rel_targets;
+    /*
+     * In case the query contains aggregations, the lists below details which
+     * functions correspond to which columns.
+     * List elements are themselves Lists of String nodes, denoting agg key,
+     * operation and column names, respectively. The agg key corresponds to the
+     * upper_rel_targets list entries.
+     */
+	List *aggs;
+    /*
+     * List containing GROUP BY information.
+     * List elements are column names for grouping.
+     */
+	List *group_clauses;
 }	MulticornExecState;
 
 typedef struct MulticornModifyState
@@ -158,6 +281,16 @@ typedef struct MulticornDeparsedSortGroup
 	PathKey	*key;
 } MulticornDeparsedSortGroup;
 
+/* deparse.c */
+extern bool multicorn_is_foreign_expr(PlannerInfo *root,
+								      RelOptInfo *baserel,
+								      Expr *expr);
+extern bool multicorn_is_foreign_param(PlannerInfo *root,
+									   RelOptInfo *baserel,
+									   Expr *expr);
+extern List *multicorn_build_tlist_to_deparse(RelOptInfo *foreignrel);
+extern void multicorn_extract_upper_rel_info(PlannerInfo *root, List *tlist, MulticornPlanState *fpinfo);
+
 /* errors.c */
 void		errorCheck(void);
 
@@ -201,10 +334,9 @@ void extractRestrictions(Relids base_relids,
 					List **quals);
 List	   *extractColumns(List *reltargetlist, List *restrictinfolist);
 void initConversioninfo(ConversionInfo ** cinfo,
-		AttInMetadata *attinmeta);
+		AttInMetadata *attinmeta, List *upper_rel_targets);
 
-Value *colnameFromVar(Var *var, PlannerInfo *root,
-		MulticornPlanState * state);
+Value *colnameFromVar(Var *var, PlannerInfo *root);
 
 void computeDeparsedSortGroup(List *deparsed, MulticornPlanState *planstate,
 		List **apply_pathkeys,

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -102,9 +102,9 @@ typedef struct MulticornPlanState
 
     /* Details about upperrel pushdown fetched from the Python FDW instance */
     bool groupby_supported;
-    PyObject *agg_functions;
+    List *agg_functions;
 
-        /*
+    /*
      * Aggregation and grouping data to be passed to the execution phase.
      * See MulticornExecState for more details.
      */

--- a/src/python.c
+++ b/src/python.c
@@ -1007,6 +1007,7 @@ execute(ForeignScanState *node, ExplainState *es)
             {
                 PyObject *column = PyUnicode_FromString(strVal(lfirst(lc_groupc)));
                 PyList_Append(group_clauses, column);
+                Py_DECREF(column);
             }
 
             PyDict_SetItemString(kwargs, "group_clauses", group_clauses);
@@ -1712,21 +1713,21 @@ canPushdownUpperrel(MulticornPlanState * state)
         if (p_object != NULL && p_object != Py_None)
 		{
             state->groupby_supported = PyObject_IsTrue(p_object);
-            Py_DECREF(p_object);
 		}
+        Py_XDECREF(p_object);
 
         /* Determine which aggregation functions are supported */
         p_object = PyMapping_GetItemString(p_upperrel_pushdown, "agg_functions");
         if (p_object != NULL && p_object != Py_None)
 		{
             state->agg_functions = PyMapping_Keys(p_object);
-            Py_DECREF(p_object);
 		}
+        Py_XDECREF(p_object);
 
         pushdown_upperrel = true;
     }
 
-	Py_DECREF(p_upperrel_pushdown);
+	Py_XDECREF(p_upperrel_pushdown);
     return pushdown_upperrel;
 }
 

--- a/src/python.c
+++ b/src/python.c
@@ -1069,8 +1069,7 @@ pynumberToCString(PyObject *pyobject, StringInfo buffer,
         /*
          * Certain data sources, such as ElasticSearch, can return floats for
          * aggregations of integers that are expected to return integers
-         * (e.g. ElasticSearch for min, max, sum), so we basically need to do
-         * int() here.
+         * (e.g. min, max, sum), so we basically need to do int() here.
          */
         pyobject = PyNumber_Long(pyobject);
     }

--- a/src/python.c
+++ b/src/python.c
@@ -1061,6 +1061,14 @@ pynumberToCString(PyObject *pyobject, StringInfo buffer,
 	char	   *tempbuffer;
 	Py_ssize_t	strlength = 0;
 
+    if (
+        !PyLong_Check(pyobject) &&
+        (cinfo->atttypoid == INT2OID || cinfo->atttypoid == INT4OID || cinfo->atttypoid == INT8OID)
+    )
+    {
+        pyobject = PyNumber_Long(pyobject);
+    }
+
 	pTempStr = PyObject_Str(pyobject);
 	PyString_AsStringAndSize(pTempStr, &tempbuffer, &strlength);
 	appendBinaryStringInfo(buffer, tempbuffer, strlength);

--- a/src/python.c
+++ b/src/python.c
@@ -1057,7 +1057,7 @@ void
 pynumberToCString(PyObject *pyobject, StringInfo buffer,
 				  ConversionInfo * cinfo)
 {
-	PyObject   *pTempStr;
+	PyObject   *pTempStr, *pyTempLong;
 	char	   *tempbuffer;
 	Py_ssize_t	strlength = 0;
 
@@ -1071,10 +1071,15 @@ pynumberToCString(PyObject *pyobject, StringInfo buffer,
          * aggregations of integers that are expected to return integers
          * (e.g. min, max, sum), so we basically need to do int() here.
          */
-        pyobject = PyNumber_Long(pyobject);
+        pyTempLong = PyNumber_Long(pyobject);
+        pTempStr = PyObject_Str(pyTempLong);
+        Py_DECREF(pyTempLong);
+    }
+    else
+    {
+        pTempStr = PyObject_Str(pyobject);
     }
 
-	pTempStr = PyObject_Str(pyobject);
 	PyString_AsStringAndSize(pTempStr, &tempbuffer, &strlength);
 	appendBinaryStringInfo(buffer, tempbuffer, strlength);
 	Py_DECREF(pTempStr);

--- a/src/python.c
+++ b/src/python.c
@@ -1700,7 +1700,6 @@ canPushdownUpperrel(MulticornPlanState * state)
     PyObject    *fdw_instance = state->fdw_instance,
                 *p_upperrel_pushdown,
                 *p_object;
-	Py_ssize_t	i, size;
     bool pushdown_upperrel = false;
 
     p_upperrel_pushdown = PyObject_CallMethod(fdw_instance, "can_pushdown_upperrel", "()");

--- a/src/python.c
+++ b/src/python.c
@@ -1066,6 +1066,12 @@ pynumberToCString(PyObject *pyobject, StringInfo buffer,
         (cinfo->atttypoid == INT2OID || cinfo->atttypoid == INT4OID || cinfo->atttypoid == INT8OID)
     )
     {
+        /*
+         * Certain data sources, such as ElasticSearch, can return floats for
+         * aggregations of integers that are expected to return integers
+         * (e.g. ElasticSearch for min, max, sum), so we basically need to do
+         * int() here.
+         */
         pyobject = PyNumber_Long(pyobject);
     }
 


### PR DESCRIPTION
Multicorn support for Python FDW instances pushdown of an arbitrary combination of bare aggregations and/or groupings.

- Accompanying PR demonstrating a particular implementation (in Elasticsearch) is https://github.com/splitgraph/postgres-elasticsearch-fdw/pull/1.
- For now it does not support pushdown of `HAVING` clauses or `WHERE` clauses in case of aggregations. This case results in full record fetch and then subsequent filtering/aggregation on the PG side.
- Does not support pushdown of `ORDER BY` clauses, but in this case it does push down the aggregation, and performs only the ordering of returned aggregations on the PG side (so it's an improvement, albeit there's still some work to be done on doing sorting on the remote server).
- Also not supported are aggregations with `DISTINCT` or `COUNT(*)` for the time being (defaults to full record fetch and subsequent processing on PG side).
- Implementation was guided by `postgres_fdw` and other FDW implementations.

CU-1x57q56