### PR TITLE
Fix relation table index fetching for upper rels

### DIFF
--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -121,6 +121,7 @@ typedef struct MulticornPlanState
 
 	/* qual clauses */
 	List	   *baserestrictinfo;
+    Value *rtindex;
 
     /* Actual remote restriction clauses for scan (sans RestrictInfos) */
 	List	   *final_remote_exprs;
@@ -197,6 +198,7 @@ typedef struct MulticornExecState
      * Qual conditions parsed in the MulticornGetForeignRelSize
      */
     List *baserestrictinfo;
+    Value *rtindex;
 
 	/* Common buffer to avoid repeated allocations */
 	StringInfo	buffer;


### PR DESCRIPTION
This only concerns a very rare edge case, namely the case where we have a join statement between two subqueries which are aggregations that also have `WHERE` clauses, e.g.

```sql
SELECT t1.state, t2.state, t1.min FROM (
      select state, min(age) FROM es.account WHERE balance > 35000 GROUP BY state
  ) AS t1
  INNER JOIN (
      select state, max(age) FROM es.account WHERE balance > 35000 GROUP BY state
  ) AS t2
  ON t1.min = t2.max
```